### PR TITLE
Use StandardError instead of Exception.

### DIFF
--- a/lib/sparkpost_rails/exceptions.rb
+++ b/lib/sparkpost_rails/exceptions.rb
@@ -1,4 +1,4 @@
 module SparkPostRails
-  class DeliveryException < Exception
+  class DeliveryException < StandardError
   end
 end


### PR DESCRIPTION
Exception will result in bad things like the standard rescue not working. This can result in issues such as servers shutting down or queue managers dying (delayed_job does for sure)

Causes #12 