### PR TITLE
Add :inline_css parameter to sparkpost_options and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ SparkPostRails.configure do |c|
   c.campaign_id = 'YOUR-CAMPAIGN'
   c.transactional = true
   c.ip_pool = "MY-POOL"
+  c.inline_css = true
   c.subaccount = "123"
 end
 ```
@@ -61,6 +62,7 @@ return_path = nil
 campaign_id = nil
 transactional = false
 ip_pool = nil
+inline_css = false
 subaccount = nil
 ```
 

--- a/lib/sparkpost_rails.rb
+++ b/lib/sparkpost_rails.rb
@@ -24,6 +24,7 @@ module SparkPostRails
 
     attr_accessor :transactional
     attr_accessor :ip_pool
+    attr_accessor :inline_css
 
     attr_accessor :subaccount
 
@@ -48,6 +49,7 @@ module SparkPostRails
 
       @transactional = false
       @ip_pool = nil
+      @inline_css = false
 
       @subaccount = nil
     end

--- a/lib/sparkpost_rails/delivery_method.rb
+++ b/lib/sparkpost_rails/delivery_method.rb
@@ -196,6 +196,7 @@ module SparkPostRails
       prepare_transactional_from sparkpost_data
       prepare_skip_suppression_from sparkpost_data
       prepare_ip_pool_from sparkpost_data
+      prepare_inline_css_from sparkpost_data
       prepare_delivery_schedule_from mail
     end
 
@@ -283,6 +284,14 @@ module SparkPostRails
 
       if ip_pool
         @data[:options][:ip_pool] = ip_pool
+      end
+    end
+
+    def prepare_inline_css_from sparkpost_data
+      @data[:options][:inline_css] = SparkPostRails.configuration.inline_css
+
+      if sparkpost_data.has_key?(:inline_css)
+        @data[:options][:inline_css] = sparkpost_data[:inline_css]
       end
     end
 

--- a/spec/inline_css_spec.rb
+++ b/spec/inline_css_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+describe SparkPostRails::DeliveryMethod do
+
+  before(:each) do
+    SparkPostRails.configuration.set_defaults
+    @delivery_method = SparkPostRails::DeliveryMethod.new
+  end
+
+  context "Inline css" do
+    it "handles inline_css set in the configuration" do
+      SparkPostRails.configure do |c|
+        c.inline_css = true
+      end
+
+      test_email = Mailer.test_email
+      @delivery_method.deliver!(test_email)
+
+      expect(@delivery_method.data[:options][:inline_css]).to eq(true)
+    end
+
+    it "handles inline_css set on an individual message" do
+      test_email = Mailer.test_email sparkpost_data: {inline_css: true}
+
+      @delivery_method.deliver!(test_email)
+
+      expect(@delivery_method.data[:options][:inline_css]).to eq(true)
+    end
+
+    it "handles the value on an individual message overriding configuration" do
+      SparkPostRails.configure do |c|
+        c.inline_css = false
+      end
+
+      test_email = Mailer.test_email sparkpost_data: {inline_css: true}
+
+      @delivery_method.deliver!(test_email)
+
+      expect(@delivery_method.data[:options][:inline_css]).to eq(true)
+    end
+
+    it "handles a default setting of inline_css" do
+      test_email = Mailer.test_email
+      @delivery_method.deliver!(test_email)
+
+      expect(@delivery_method.data[:options][:inline_css]).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
According to [docs](https://developers.sparkpost.com/api/#/reference/transmissions), `inline_css` is an option for transmission that is set to `false` by default.
I do not see that this option handled anywhere in the gem, so I've added a few lines of code that will pass this parameter either from `sparkpost_options` from individual email or from `configuration` in the initializers.
