### PR TITLE
Add support for recipient-specific data

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,21 @@ data = { substitution_data: sub_data }
 mail(to: to_email, subject: "Test", body: "test", sparkpost_data: data)
 ```
 
+### Recipient-specific Data
+When sending to multiple recipients, you can pass an array of data to complement each recipient. Simply pass an array called recipients containing an array of the additional data (e.g. substitution_data).
+
+```
+recipients = ['recipient1@email.com', 'recipient2@email.com']
+sparkpost_data = {
+  recipients: [
+    { substitution_data: { name: 'Recipient1' } },
+    { substitution_data: { name: 'Recipient2' } }
+  ]
+}
+mail(to: recipients, sparkpost_data: sparkpost_data)
+```
+
+
 ### Using SparkPost Templates
 If you would rather leverage SparkPost's powerful templates rather than building ActionMailer views, SparkPostRails can support that as well.  Simply
 add your template id to the sparkpost_data hash:

--- a/lib/sparkpost_rails/delivery_method.rb
+++ b/lib/sparkpost_rails/delivery_method.rb
@@ -14,6 +14,7 @@ module SparkPostRails
       sparkpost_data = find_sparkpost_data_from mail
 
       prepare_recipients_from mail, sparkpost_data
+      prepare_recipients_data_from sparkpost_data
 
       if sparkpost_data.has_key?(:template_id)
         prepare_template_content_from sparkpost_data
@@ -92,6 +93,17 @@ module SparkPostRails
         { address: { email: email, header_to: header_to } }
       else
         { address: { email: email } }
+      end
+    end
+
+    # See https://developers.sparkpost.com/api/#/introduction/substitutions-reference/links-and-substitution-expressions-within-substitution-values
+    def prepare_recipients_data_from sparkpost_data
+      if (recipients_data = sparkpost_data[:recipients])
+        @data[:recipients].each_with_index do |recipient, index|
+          if (recipient_data = recipients_data[index])
+            recipient.merge!(recipient_data)
+          end
+        end
       end
     end
 

--- a/spec/recipient_specific_data_spec.rb
+++ b/spec/recipient_specific_data_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe SparkPostRails::DeliveryMethod do
+
+  before(:each) do
+    @delivery_method = SparkPostRails::DeliveryMethod.new
+  end
+
+  context "Recipient Data" do
+
+    it "accepts data matching all recipients" do
+      recipients = ['recipient1@email.com', 'recipient2@email.com']
+      recipients_data = [
+        {substitution_data: {name: "Recipient1"}}, 
+        {substitution_data: {name: "Recipient2"}} 
+      ]
+
+      test_email = Mailer.test_email to: recipients, sparkpost_data: {recipients: recipients_data}
+
+      @delivery_method.deliver!(test_email)
+
+      actual_recipients = @delivery_method.data[:recipients]
+      expect(actual_recipients.length).to eq(recipients.length)
+      expect(actual_recipients).to eq(recipients.each_with_index.map { |recipient, index| recipients_data[index].merge(address: {email: recipient}) })
+    end
+
+  end
+end
+
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,7 +23,7 @@ class Mailer < ActionMailer::Base
   def test_email options = {}
     data = {
       from: "from@example.com",
-      to: "to@example.com",
+      to: options[:to] || "to@example.com",
       subject: "Test Email",
       text_part: "Hello, Testing!"
     }


### PR DESCRIPTION
This adds the capability to allow substitution data to be attached to a specific recipient (instead of to all recipients).

This is based on the substitution feature mentioned in: 

https://developers.sparkpost.com/api/#/introduction/substitutions-reference/links-and-substitution-expressions-within-substitution-values

Example usage:

```
recipients = ['recipient1@email.com', 'recipient2@email.com']
sparkpost_data = {
  recipients: [
    { substitution_data: { name: 'Recipient1' } },
    { substitution_data: { name: 'Recipient2' } }
  ]
}
mail(to: recipients, sparkpost_data: sparkpost_data)
```