### PR TITLE
Relax constraints to allow Rails 5

### DIFF
--- a/sparkpost_rails.gemspec
+++ b/sparkpost_rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{lib}/**/*"] + ["LICENSE", "README.md"]
   s.test_files = Dir["{spec}/**/*"]
 
-  s.add_dependency 'rails', '~> 4.0'
+  s.add_dependency 'rails', '>= 4.0', '< 5.1'
 
   s.add_development_dependency "rspec", '>= 3.4.0'
   s.add_development_dependency "webmock", '>= 1.24.2'


### PR DESCRIPTION
Since 5.0.0.rc1 is now out, I believe we should relax the requirements on `rails`.

Nothing in the [changelog](https://github.com/rails/rails/blob/5-0-stable/actionmailer/CHANGELOG.md) jumps out at me that would break this gem's functionality.

This'll need to be thoroughly tested once 5.0.0 becomes "stable".