### PR TITLE
Set html content for email with multipart false option.

### DIFF
--- a/lib/sparkpost_rails/delivery_method.rb
+++ b/lib/sparkpost_rails/delivery_method.rb
@@ -150,7 +150,7 @@ module SparkPostRails
           @data[:content][:text] = cleanse_encoding(mail.text_part.body.to_s)
         end
       else
-        @data[:content][:text] = cleanse_encoding(mail.body.to_s)
+        @data[:content][:html] = cleanse_encoding(mail.body.to_s)
       end
     end
 


### PR DESCRIPTION
Email with HTML content is delivered as plain text with HTML tags. 
Fixed it by changing `lib/sparkpost_rails/delivery_method.rb` But don't know whether it is the correct approach or not .
