### PR TITLE
Added Support for Enteprise SparkPost

### DIFF
--- a/lib/sparkpost_rails.rb
+++ b/lib/sparkpost_rails.rb
@@ -36,6 +36,8 @@ module SparkPostRails
 
     attr_accessor :subaccount
 
+    attr_accessor :http_proxy
+
     def initialize
       set_defaults
     end

--- a/lib/sparkpost_rails.rb
+++ b/lib/sparkpost_rails.rb
@@ -18,8 +18,11 @@ module SparkPostRails
 
   class Configuration
     attr_accessor :api_key
+    attr_accessor :api_endpoint
+    attr_accessor :api_binding
     attr_accessor :sandbox
 
+    attr_accessor :mailtype
     attr_accessor :track_opens
     attr_accessor :track_clicks
 

--- a/lib/sparkpost_rails/delivery_method.rb
+++ b/lib/sparkpost_rails/delivery_method.rb
@@ -374,7 +374,7 @@ module SparkPostRails
     end
 
     def post_to_api
-      url = "https://api.sparkpost.com/api/v1/transmissions"
+      url = "https://guardian.msyscloud.com/api/v1/transmissions"
 
       uri = URI.parse(url)
       http = Net::HTTP.new(uri.host, uri.port)

--- a/lib/sparkpost_rails/delivery_method.rb
+++ b/lib/sparkpost_rails/delivery_method.rb
@@ -387,6 +387,15 @@ module SparkPostRails
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
 
+      if SparkPostRails.configuration.http_proxy
+        proxy_uri = URI(SparkPostRails.configuration.http_proxy)
+        http.proxy_from_env = false # make sure proxy settings can be overridden
+        http.proxy_address = proxy_uri.host
+        http.proxy_port = proxy_uri.port
+        http.proxy_user = proxy_uri.user if proxy_uri.user
+        http.proxy_pass = proxy_uri.password if proxy_uri.password 
+      end
+
       request = Net::HTTP::Post.new(uri.path, @headers)
       request.body = JSON.generate(@data)
 

--- a/lib/sparkpost_rails/delivery_method.rb
+++ b/lib/sparkpost_rails/delivery_method.rb
@@ -28,6 +28,7 @@ module SparkPostRails
         prepare_attachments_from mail
       end
 
+      prepare_metadata
       prepare_substitution_data_from sparkpost_data
       prepare_description_from sparkpost_data
       prepare_options_from mail, sparkpost_data
@@ -41,6 +42,12 @@ module SparkPostRails
     end
 
   private
+    def prepare_metadata
+      @data[:metadata] = Hash.new
+      @data[:metadata][:binding] = SparkPostRails.configuration.api_binding
+      @data[:metadata][:mailtype]= SparkPostRails.configuration.mailtype
+    end
+
     def find_sparkpost_data_from mail
       if mail[:sparkpost_data]
         eval(mail[:sparkpost_data].value)
@@ -374,7 +381,7 @@ module SparkPostRails
     end
 
     def post_to_api
-      url = "https://guardian.msyscloud.com/api/v1/transmissions"
+      url = SparkPostRails.configuration.api_endpoint
 
       uri = URI.parse(url)
       http = Net::HTTP.new(uri.host, uri.port)


### PR DESCRIPTION
Enteprise SparkPost allows you to specify and API Endpoint. It's not the default SpakPost API that is hard coded into the code. I added support to be able to pass that as a configuration item. 

Fixed a bug where the CC e-mail headers weren't being passes in the form sparkpost expects. 