### PR TITLE
Update dependency restriction to support rails 5.1

### DIFF
--- a/sparkpost_rails.gemspec
+++ b/sparkpost_rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{lib}/**/*"] + ["LICENSE", "README.md"]
   s.test_files = Dir["{spec}/**/*"]
 
-  s.add_dependency 'rails', '>= 4.0', '< 5.1'
+  s.add_dependency 'rails', '>= 4.0', '< 5.2'
 
   s.add_development_dependency "rspec", '>= 3.4.0'
   s.add_development_dependency "webmock", '>= 1.24.2'


### PR DESCRIPTION
Fixes https://github.com/the-refinery/sparkpost_rails/issues/41

Note specs are failing since the needed templates don't seem to be included in the repository. 
```
Failure/Error: format.text {render text: data[:text_part]}

      ActionView::MissingTemplate:
        Missing template mailer/test_email with {:locale=>[:en], :formats=>[:text], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby]}
```