### PR TITLE
Allow custom API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ You can establish values for a number of SparkPost settings in the initializer. 
 
 ```ruby
 SparkPostRails.configure do |c|
+  c.api_endpoint = "https://api.eu.sparkpost.com/api/v1/transmissions" # default: "https://api.sparkpost.com/api/v1/transmissions"
   c.sandbox = true                                # default: false
   c.track_opens = true                            # default: false
   c.track_clicks = true                           # default: false

--- a/lib/sparkpost_rails.rb
+++ b/lib/sparkpost_rails.rb
@@ -18,6 +18,7 @@ module SparkPostRails
   end
 
   class Configuration
+    attr_accessor :api_endpoint
     attr_accessor :api_key
     attr_accessor :sandbox
 
@@ -44,6 +45,8 @@ module SparkPostRails
       else
         @api_key = ""
       end
+
+      @api_endpoint = "https://api.sparkpost.com/api/v1/transmissions"
 
       @sandbox = false
 

--- a/lib/sparkpost_rails/delivery_method.rb
+++ b/lib/sparkpost_rails/delivery_method.rb
@@ -377,7 +377,7 @@ module SparkPostRails
     end
 
     def post_to_api
-      url = "https://api.sparkpost.com/api/v1/transmissions"
+      url = SparkPostRails.configuration.api_endpoint
 
       uri = URI.parse(url)
       http = Net::HTTP.new(uri.host, uri.port)


### PR DESCRIPTION
From the [api docs](https://developers.sparkpost.com/api/#header-endpoints):

> All calls to the API need to start with the appropriate base URL
> SparkPost | https://api.sparkpost.com/api/v1
> SparkPost EU | https://api.eu.sparkpost.com/api/v1

This PR allows setting the appropriate API endpoint. I notice there's already another PR which kind of conflicts with this one: #43, so probably you'll want to either merge this first and then rebase that one, or just merge that one, considering that it's not only about Enterprise, but also anyone using the EU servers.
