### PR TITLE
Add support for configurable api endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,16 +38,17 @@ You can establish values for a number of SparkPost settings in the initializer. 
 
 ```ruby
 SparkPostRails.configure do |c|
-  c.sandbox = true                                # default: false
-  c.track_opens = true                            # default: false
-  c.track_clicks = true                           # default: false
-  c.return_path = 'BOUNCE-EMAIL@YOUR-DOMAIN.COM'  # default: nil
-  c.campaign_id = 'YOUR-CAMPAIGN'                 # default: nil
-  c.transactional = true                          # default: false
-  c.ip_pool = "MY-POOL"                           # default: nil
-  c.inline_css = true                             # default: false
-  c.html_content_only = true                      # default: false
-  c.subaccount = "123"                            # default: nil
+  c.api_endpoint = "https://api.eu.sparkpost.com/api/" # default: "https://api.sparkpost.com/api/"
+  c.sandbox = true                                     # default: false
+  c.track_opens = true                                 # default: false
+  c.track_clicks = true                                # default: false
+  c.return_path = 'BOUNCE-EMAIL@YOUR-DOMAIN.COM'       # default: nil
+  c.campaign_id = 'YOUR-CAMPAIGN'                      # default: nil
+  c.transactional = true                               # default: false
+  c.ip_pool = "MY-POOL"                                # default: nil
+  c.inline_css = true                                  # default: false
+  c.html_content_only = true                           # default: false
+  c.subaccount = "123"                                 # default: nil
 end
 ```
 
@@ -81,6 +82,7 @@ If you are using `ActiveJob` and wish to do something special when the SparkPost
 
 ```ruby
 ActionMailer::DeliveryJob.rescue_from(SparkPostRails::DeliveryException) do |exception|
+  # do something special with the error
   # do something special with the error
 end
 ```

--- a/lib/sparkpost_rails.rb
+++ b/lib/sparkpost_rails.rb
@@ -19,6 +19,7 @@ module SparkPostRails
 
   class Configuration
     attr_accessor :api_key
+    attr_accessor :api_endpoint
     attr_accessor :sandbox
 
     attr_accessor :track_opens
@@ -44,6 +45,8 @@ module SparkPostRails
       else
         @api_key = ""
       end
+
+      @api_endpoint = "https://api.sparkpost.com/api/"
 
       @sandbox = false
 

--- a/lib/sparkpost_rails/delivery_method.rb
+++ b/lib/sparkpost_rails/delivery_method.rb
@@ -377,9 +377,8 @@ module SparkPostRails
     end
 
     def post_to_api
-      url = "https://api.sparkpost.com/api/v1/transmissions"
+      uri = URI.join(SparkPostRails.configuration.api_endpoint, 'v1/transmissions')
 
-      uri = URI.parse(url)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
 

--- a/spec/response_spec.rb
+++ b/spec/response_spec.rb
@@ -15,7 +15,8 @@ describe SparkPostRails::DeliveryMethod do
     end
 
     it "raises exception on error" do
-      stub_request(:any, "https://api.sparkpost.com/api/v1/transmissions").
+      uri = URI.join(SparkPostRails.configuration.api_endpoint, 'v1/transmissions')
+      stub_request(:any, uri.to_s).
         to_return(body: "{\"errors\":[{\"message\":\"required field is missing\",\"description\":\"recipients or list_id required\",\"code\":\"1400\"}]}", status: 403)
 
       test_email = Mailer.test_email

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,8 +17,8 @@ RSpec.configure do |config|
         c.api_key = "TESTKEY1234"
       end
     end
-
-    stub_request(:any, "https://api.sparkpost.com/api/v1/transmissions").
+    uri = URI.join(SparkPostRails.configuration.api_endpoint, 'v1/transmissions')
+    stub_request(:any, uri.to_s).
       to_return(body: "{\"results\":{\"total_rejected_recipients\":0,\"total_accepted_recipients\":1,\"id\":\"00000000000000000\"}}", status: 200)
   end
 


### PR DESCRIPTION
To enable using eu endpoint for API this needs to be configurable. I've added so the full URL is possible to configure.

To test this add this to `initializers/sparkpost_rails.rb`
```
c.api_endpoint = "https://api.eu.sparkpost.com/api/"
```
for a Sparkpost account in EU.

This is similar to https://github.com/the-refinery/sparkpost_rails/pull/58/files but have some pros
- It does not include the version in the configuration option so in case of bump in API version it's not needed to reconfigure
- Tests are actually testing using the configuration variable
- If additional API paths were to be added it can be reused.