### PR TITLE
Add support for Rails 8

### DIFF
--- a/sparkpost_rails.gemspec
+++ b/sparkpost_rails.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |s|
   s.files = Dir["{lib}/**/*"] + ["LICENSE", "README.md"]
   s.test_files = Dir["{spec}/**/*"]
 
-  s.add_dependency 'actionmailer', '>= 4.0', '< 8'
-  s.add_dependency 'railties', '>= 4.0', '< 8'
+  s.add_dependency 'actionmailer', '>= 4.0', '< 9'
+  s.add_dependency 'railties', '>= 4.0', '< 9'
 
   s.add_development_dependency "rspec", '>= 3.4.0'
   s.add_development_dependency "webmock", '>= 1.24.2'

--- a/sparkpost_rails.gemspec
+++ b/sparkpost_rails.gemspec
@@ -15,9 +15,8 @@ Gem::Specification.new do |s|
   s.files = Dir["{lib}/**/*"] + ["LICENSE", "README.md"]
   s.test_files = Dir["{spec}/**/*"]
 
-  %w[actionmailer railties].each do |rails_gem|
-    s.add_dependency rails_gem, '>= 4.0', '< 6.2'
-  end
+  s.add_dependency 'actionmailer', '>= 4.0'
+  s.add_dependency 'railties', '>= 4.0'
 
   s.add_development_dependency "rspec", '>= 3.4.0'
   s.add_development_dependency "webmock", '>= 1.24.2'

--- a/sparkpost_rails.gemspec
+++ b/sparkpost_rails.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |s|
   s.files = Dir["{lib}/**/*"] + ["LICENSE", "README.md"]
   s.test_files = Dir["{spec}/**/*"]
 
-  s.add_dependency 'actionmailer', '>= 4.0', '< 7'
-  s.add_dependency 'railties', '>= 4.0', '< 7'
+  s.add_dependency 'actionmailer', '>= 4.0', '< 8'
+  s.add_dependency 'railties', '>= 4.0', '< 8'
 
   s.add_development_dependency "rspec", '>= 3.4.0'
   s.add_development_dependency "webmock", '>= 1.24.2'

--- a/sparkpost_rails.gemspec
+++ b/sparkpost_rails.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |s|
   s.files = Dir["{lib}/**/*"] + ["LICENSE", "README.md"]
   s.test_files = Dir["{spec}/**/*"]
 
-  s.add_dependency 'actionmailer', '>= 4.0'
-  s.add_dependency 'railties', '>= 4.0'
+  s.add_dependency 'actionmailer', '>= 4.0', '< 7'
+  s.add_dependency 'railties', '>= 4.0', '< 7'
 
   s.add_development_dependency "rspec", '>= 3.4.0'
   s.add_development_dependency "webmock", '>= 1.24.2'


### PR DESCRIPTION
Required to support the latest version of Rails.

Simplified the loop as well in order for automated tools such as dependabot to more easily create automated pull requests.

Use this in your `Gemfile` in the meantime:

```rb
# Send emails through SparkPost.
# Using fork to support Rails 8
# See also https://github.com/the-refinery/sparkpost_rails/pull/89
gem "sparkpost_rails",
    git: "https://github.com/sunny/sparkpost_rails.git",
    ref: "1d90bc7026ad3e4fc9af09819d5afe80934b5475"
```